### PR TITLE
feat(i18n): suporte a múltiplos idiomas + LanguageSwitcher e correções de tradução

### DIFF
--- a/imuno/package-lock.json
+++ b/imuno/package-lock.json
@@ -8,10 +8,13 @@
       "name": "vite-react-typescript-starter",
       "version": "0.0.0",
       "dependencies": {
+        "i18next": "^25.6.0",
+        "i18next-browser-languagedetector": "^8.2.0",
         "konva": "^9.3.3",
         "lucide-react": "^0.344.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
+        "react-i18next": "^16.0.1",
         "react-konva": "^18.2.10"
       },
       "devDependencies": {
@@ -290,6 +293,15 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.4.tgz",
+      "integrity": "sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template": {
@@ -2523,6 +2535,55 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/html-parse-stringify": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/html-parse-stringify/-/html-parse-stringify-3.0.1.tgz",
+      "integrity": "sha512-KknJ50kTInJ7qIScF3jeaFRpMpE8/lfiTdzf/twXyPBLAGrLRTmkz3AdTnKeh40X8k9L2fdYwEp/42WGXIRGcg==",
+      "license": "MIT",
+      "dependencies": {
+        "void-elements": "3.1.0"
+      }
+    },
+    "node_modules/i18next": {
+      "version": "25.6.0",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-25.6.0.tgz",
+      "integrity": "sha512-tTn8fLrwBYtnclpL5aPXK/tAYBLWVvoHM1zdfXoRNLcI+RvtMsoZRV98ePlaW3khHYKuNh/Q65W/+NVFUeIwVw==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://locize.com"
+        },
+        {
+          "type": "individual",
+          "url": "https://locize.com/i18next.html"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.i18next.com/how-to/faq#i18next-is-awesome.-how-can-i-support-the-project"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.27.6"
+      },
+      "peerDependencies": {
+        "typescript": "^5"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/i18next-browser-languagedetector": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/i18next-browser-languagedetector/-/i18next-browser-languagedetector-8.2.0.tgz",
+      "integrity": "sha512-P+3zEKLnOF0qmiesW383vsLdtQVyKtCNA9cjSoKCppTKPQVfKd2W8hbVo5ZhNJKDqeM7BOcvNoKJOjpHh4Js9g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.23.2"
+      }
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -3317,6 +3378,32 @@
         "react": "^18.3.1"
       }
     },
+    "node_modules/react-i18next": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-16.0.1.tgz",
+      "integrity": "sha512-0S//bpYEkCPjzuVmxDf9Z6+Y+ArNvpAUk7eDL4qNCZXjDh6Z9j6MZ+NThU7kMCOsmYmDCun3GYEwkiOjjZo9Ug==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.27.6",
+        "html-parse-stringify": "^3.0.1"
+      },
+      "peerDependencies": {
+        "i18next": ">= 25.5.2",
+        "react": ">= 16.8.0",
+        "typescript": "^5"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-konva": {
       "version": "18.2.10",
       "resolved": "https://registry.npmjs.org/react-konva/-/react-konva-18.2.10.tgz",
@@ -3818,7 +3905,7 @@
       "version": "5.6.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.3.tgz",
       "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
-      "dev": true,
+      "devOptional": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -3952,6 +4039,15 @@
         "terser": {
           "optional": true
         }
+      }
+    },
+    "node_modules/void-elements": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-3.1.0.tgz",
+      "integrity": "sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/which": {

--- a/imuno/package.json
+++ b/imuno/package.json
@@ -10,10 +10,13 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "i18next": "^25.6.0",
+    "i18next-browser-languagedetector": "^8.2.0",
     "konva": "^9.3.3",
     "lucide-react": "^0.344.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
+    "react-i18next": "^16.0.1",
     "react-konva": "^18.2.10"
   },
   "devDependencies": {

--- a/imuno/src/App.tsx
+++ b/imuno/src/App.tsx
@@ -9,9 +9,10 @@ import iconData from "./data/iconData";
 import svgCache from "./services/SvgCache";
 import { BathIcon } from "lucide-react";
 import Notification from './components/Notification/Notification.component';
+import { useTranslation } from './hooks/useTranslation';
 
 function App() {
-
+  const { t } = useTranslation();
   const [transformer, setTransformer] = useState<Konva.Transformer | null>(null);
   const [isDrawing, setIsDrawing] = useState(false);
   const [brushSize, setBrushSize] = useState(5);
@@ -483,12 +484,12 @@ function App() {
       
       showNotification(
         nodes.length === 1 
-          ? "Item copiado para a área de transferência" 
-          : `${nodes.length} itens copiados para a área de transferência`,
+          ? t('notifications.itemCopied')
+          : t('notifications.itemsCopied', { count: nodes.length }),
         "success"
       );
     } else {
-      showNotification("Nenhum item selecionado para copiar", "error");
+      showNotification(t('notifications.noItemSelected'), "error");
     }
   };
 
@@ -505,14 +506,14 @@ function App() {
       
       showNotification(
         nodes.length === 1 
-          ? "Item recortado para a área de transferência" 
-          : `${nodes.length} itens recortados para a área de transferência`,
+          ? t('notifications.itemCut')
+          : t('notifications.itemsCut', { count: nodes.length }),
         "success"
       );
     } else if (isLocked) {
-      showNotification("Não é possível recortar itens bloqueados", "error");
+      showNotification(t('notifications.cannotCutLocked'), "error");
     } else {
-      showNotification("Nenhum item selecionado para recortar", "error");
+      showNotification(t('notifications.noItemToCut'), "error");
     }
   };
 
@@ -545,12 +546,12 @@ function App() {
       
       showNotification(
         clonedNodes.length === 1 
-          ? "Item colado com sucesso" 
-          : `${clonedNodes.length} itens colados com sucesso`,
+          ? t('notifications.itemPasted')
+          : t('notifications.itemsPasted', { count: clonedNodes.length }),
         "success"
       );
     } else {
-      showNotification("Nada para colar. Copie um item primeiro.", "info");
+      showNotification(t('notifications.nothingToPaste'), "info");
     }
   };
 
@@ -1062,7 +1063,7 @@ function App() {
       const loadingText = new Konva.Text({
         x: x,
         y: y,
-        text: "Carregando SVG...",
+        text: t('notifications.loadingSvg'),
         fontSize: 14,
         fill: "#333",
         padding: 10,
@@ -1098,7 +1099,7 @@ function App() {
 
         image.onerror = () => {
           // Em caso de erro, mostrar uma mensagem
-          loadingText.text("Erro ao carregar SVG");
+          loadingText.text(t('notifications.errorLoadingSvg'));
           loadingText.fill("red");
           layer.draw();
 
@@ -1405,7 +1406,7 @@ function App() {
 
         // Criar o texto com placeholder
         const text = new Konva.Text({
-          text: textContent || "Clique duplo para editar",
+          text: textContent || t('notifications.doubleClickToEdit'),
           fontSize: 14,
           fontFamily: "Inter, sans-serif",
           fill: "#2D3748",
@@ -1557,7 +1558,7 @@ function App() {
       if (!document.body.contains(textarea)) return;
 
       // Aplicar o texto ao nó
-      textNode.text(textarea.value || "Clique duplo para editar");
+      textNode.text(textarea.value || t('notifications.doubleClickToEdit'));
 
       // Remover o textarea
       document.body.removeChild(textarea);

--- a/imuno/src/components/LanguageSwitcher/LanguageSwitcher.component.tsx
+++ b/imuno/src/components/LanguageSwitcher/LanguageSwitcher.component.tsx
@@ -1,0 +1,64 @@
+import React, { useState } from 'react';
+import { Globe, ChevronDown } from 'lucide-react';
+import { useTranslation } from '../../hooks/useTranslation';
+
+const LanguageSwitcher: React.FC = () => {
+  const { changeLanguage, getCurrentLanguage, getAvailableLanguages } = useTranslation();
+  const [isOpen, setIsOpen] = useState(false);
+  const currentLanguage = getCurrentLanguage();
+  const availableLanguages = getAvailableLanguages();
+
+  const handleLanguageChange = (languageCode: string) => {
+    changeLanguage(languageCode);
+    setIsOpen(false);
+  };
+
+  const getCurrentLanguageName = () => {
+    const lang = availableLanguages.find(l => l.code === currentLanguage);
+    return lang ? lang.name : 'Português (Brasil)';
+  };
+
+  return (
+    <div className="relative">
+      <button
+        onClick={() => setIsOpen(!isOpen)}
+        className="inline-flex items-center px-3 py-2 border border-gray-200 rounded-md text-sm font-medium text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
+      >
+        <Globe className="h-4 w-4 mr-2" />
+        {getCurrentLanguageName()}
+        <ChevronDown className="h-4 w-4 ml-2" />
+      </button>
+
+      {isOpen && (
+        <>
+          {/* Overlay para fechar o dropdown */}
+          <div 
+            className="fixed inset-0 z-10" 
+            onClick={() => setIsOpen(false)}
+          />
+          
+          {/* Dropdown */}
+          <div className="absolute right-0 mt-2 w-48 bg-white rounded-md shadow-lg z-20 border border-gray-200">
+            <div className="py-1">
+              {availableLanguages.map((language) => (
+                <button
+                  key={language.code}
+                  onClick={() => handleLanguageChange(language.code)}
+                  className={`w-full text-left px-4 py-2 text-sm hover:bg-gray-100 ${
+                    currentLanguage === language.code 
+                      ? 'bg-blue-50 text-blue-700 font-medium' 
+                      : 'text-gray-700'
+                  }`}
+                >
+                  {language.name}
+                </button>
+              ))}
+            </div>
+          </div>
+        </>
+      )}
+    </div>
+  );
+};
+
+export default LanguageSwitcher;

--- a/imuno/src/components/RightControls/RightControls.component.tsx
+++ b/imuno/src/components/RightControls/RightControls.component.tsx
@@ -1,5 +1,6 @@
 import React, { useRef } from 'react';
 import { Ruler, ZoomIn, ZoomOut, Grid, Eye, PaintBucket } from 'lucide-react';
+import { useTranslation } from '../../hooks/useTranslation';
 
 interface RightControlsProps {
   rulerVisible: boolean;
@@ -28,6 +29,7 @@ const RightControls: React.FC<RightControlsProps> = ({
   onZoom,
   onZoomChange,
 }) => {
+  const { t } = useTranslation();
   const sliderRef = useRef<HTMLDivElement>(null);
 
   const handleSliderClick = (e: React.MouseEvent<HTMLDivElement>) => {
@@ -56,7 +58,7 @@ const RightControls: React.FC<RightControlsProps> = ({
           <button
             className="p-2 hover:bg-gray-100 rounded-md"
             onClick={() => onZoom('in')}
-            title="Aumentar Zoom"
+            title={`${t('common.zoom')} +`}
           >
             <ZoomIn className="h-4 w-4 text-gray-600" />
           </button>
@@ -78,7 +80,7 @@ const RightControls: React.FC<RightControlsProps> = ({
           <button
             className="p-2 hover:bg-gray-100 rounded-md"
             onClick={() => onZoom('out')}
-            title="Diminuir Zoom"
+            title={`${t('common.zoom')} -`}
           >
             <ZoomOut className="h-4 w-4 text-gray-600" />
           </button>
@@ -93,7 +95,7 @@ const RightControls: React.FC<RightControlsProps> = ({
               gridVisible ? 'bg-blue-100 text-blue-700' : 'hover:bg-gray-100 text-gray-600'
             }`}
             onClick={() => onGridToggle(!gridVisible)}
-            title="Mostrar/Ocultar Grade"
+            title={t('common.grid')}
           >
             <Grid className="h-4 w-4" />
           </button>
@@ -103,7 +105,7 @@ const RightControls: React.FC<RightControlsProps> = ({
               previewMode ? 'bg-blue-100 text-blue-700' : 'hover:bg-gray-100 text-gray-600'
             }`}
             onClick={onPreviewToggle}
-            title="Modo Preview"
+            title={t('common.preview')}
           >
             <Eye className="h-4 w-4" />
           </button>
@@ -113,7 +115,7 @@ const RightControls: React.FC<RightControlsProps> = ({
               rulerVisible ? 'bg-blue-100 text-blue-700' : 'hover:bg-gray-100 text-gray-600'
             }`}
             onClick={() => onRulerToggle(!rulerVisible)}
-            title="Mostrar/Ocultar Régua"
+            title={t('common.ruler')}
           >
             <Ruler className="h-4 w-4" />
           </button>
@@ -121,7 +123,7 @@ const RightControls: React.FC<RightControlsProps> = ({
           <button
             className="p-2 hover:bg-gray-100 rounded-md text-gray-600"
             onClick={() => document.getElementById('canvas-color-picker')?.click()}
-            title="Cor do Canvas"
+            title={t('common.canvasColor')}
           >
             <PaintBucket className="h-4 w-4" />
           </button>

--- a/imuno/src/components/SearchBar.component.tsx
+++ b/imuno/src/components/SearchBar.component.tsx
@@ -1,5 +1,6 @@
 import React, { ChangeEvent, useState, useEffect } from "react";
 import { Search } from 'lucide-react';
+import { useTranslation } from '../hooks/useTranslation';
 
 interface SearchBarProps {
   onSearch: (searchTerm: string) => void;
@@ -8,8 +9,9 @@ interface SearchBarProps {
 
 const SearchBar: React.FC<SearchBarProps> = ({
   onSearch,
-  placeholder = "Search...",
+  placeholder,
 }) => {
+  const { t } = useTranslation();
   const [inputValue, setInputValue] = useState<string>("");
 
   useEffect(() => {
@@ -32,7 +34,7 @@ const SearchBar: React.FC<SearchBarProps> = ({
       <input
         type="text"
         value={inputValue}
-        placeholder={placeholder}
+        placeholder={placeholder || t('search.placeholder')}
         className="block w-full pl-10 pr-3 py-2 border border-gray-200 rounded-md text-sm placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
         onChange={handleChange}
       />

--- a/imuno/src/components/SideBar/SideBar.component.tsx
+++ b/imuno/src/components/SideBar/SideBar.component.tsx
@@ -2,6 +2,7 @@ import React, { useState } from "react";
 import SearchBar from "../SearchBar.component";
 import "./SideBar.component.css";
 import Icon from "../Icon.component";
+import { useTranslation } from "../../hooks/useTranslation";
 
 // Define a estrutura para os itens
 export interface IconItem {
@@ -20,6 +21,7 @@ interface SideBarProps {
 }
 
 const SideBar: React.FC<SideBarProps> = ({ onItemClick, items }) => {
+  const { t } = useTranslation();
   const [searchTerm, setSearchTerm] = useState<string>("");
   const [expandedCategories, setExpandedCategories] = useState<{[key: string]: boolean}>({
     immunology: true,
@@ -74,21 +76,41 @@ const SideBar: React.FC<SideBarProps> = ({ onItemClick, items }) => {
     });
   };
 
-  // Tradução dos nomes das categorias
-  const categoryNames: {[key: string]: string} = {
-    immunology: "Imunologia",
-    anatomy: "Anatomia",
-    virus: "Vírus"
+  // Mapeamento das chaves das categorias para as chaves de tradução
+  const categoryKeyMap: {[key: string]: string} = {
+    "Immunology": "immunology",
+    "Anatomy": "anatomy", 
+    "Virus": "virus",
+    "Cells and Organelles": "cellsAndOrganelles",
+    "Equipment": "equipment",
+    "Proteins": "proteins"
+  };
+
+  // Função para obter o nome traduzido da categoria
+  const getCategoryName = (category: string): string => {
+    const translationKey = categoryKeyMap[category] || category.toLowerCase();
+    return t(`categories.${translationKey}`) || category;
   };
   
-  // Tradução dos nomes das subcategorias
-  const subcategoryNames: {[key: string]: string} = {
-    organSystem: "Sistema de Órgãos",
-    skeletalSystem: "Sistema Esquelético",
-    reproductiveSystem: "Sistema Reprodutivo",
-    circulatorySystem: "Sistema Circulatório",
-    lymphaticSystem: "Sistema Linfático",
-    cellularStructures: "Estruturas Celulares"
+  // Mapeamento das chaves das subcategorias para as chaves de tradução
+  const subcategoryKeyMap: {[key: string]: string} = {
+    // Subcategorias de Anatomy
+    "Organ System": "organSystem",
+    "Skeletal System": "skeletalSystem",
+    "Reproductive System": "reproductiveSystem", 
+    "Circulatory System": "circulatorySystem",
+    "Lymphatic System": "lymphaticSystem",
+    "Cellular Structures": "cellularStructures",
+    // Subcategorias de Cells and Organelles
+    "Immune Cells": "immuneCells",
+    "Stem Cells": "stemCells",
+    "Other Cells": "otherCells"
+  };
+
+  // Função para obter o nome traduzido da subcategoria
+  const getSubcategoryName = (subcategory: string): string => {
+    const translationKey = subcategoryKeyMap[subcategory] || subcategory.toLowerCase();
+    return t(`subcategories.${translationKey}`) || subcategory;
   };
 
   // Filtrar itens com base no termo de busca
@@ -174,7 +196,7 @@ const SideBar: React.FC<SideBarProps> = ({ onItemClick, items }) => {
                   onClick={() => toggleCategory(category)}
                 >
                   <h3 className="font-bold text-gray-700">
-                    {categoryNames[category] || category}
+                    {getCategoryName(category)}
                   </h3>
                   <span>{expandedCategories[category] ? '▼' : '►'}</span>
                 </div>
@@ -193,7 +215,7 @@ const SideBar: React.FC<SideBarProps> = ({ onItemClick, items }) => {
                             onClick={() => toggleSubcategory(category, subcategory)}
                           >
                             <h4 className="font-medium text-gray-700 text-sm">
-                              {subcategoryNames[subcategory] || subcategory}
+                              {getSubcategoryName(subcategory)}
                               <span className="ml-2 text-xs text-gray-500">
                                 ({(filteredItems[category] as any)[subcategory].length})
                               </span>
@@ -213,7 +235,7 @@ const SideBar: React.FC<SideBarProps> = ({ onItemClick, items }) => {
             ))}
           </div>
         ) : (
-          <p className="text-gray-500">Nenhum item encontrado.</p>
+          <p className="text-gray-500">{t('search.noResults')}</p>
         )}
       </div>
     </div>

--- a/imuno/src/components/TopBar/TopBar.component.tsx
+++ b/imuno/src/components/TopBar/TopBar.component.tsx
@@ -5,6 +5,8 @@ import {
   Lock, Star, Layers, Crop, 
   ChevronUp, ChevronDown, PenTool
 } from 'lucide-react';
+import { useTranslation } from '../../hooks/useTranslation';
+import LanguageSwitcher from '../LanguageSwitcher/LanguageSwitcher.component';
 
 interface TopBarProps {
   onSaveClick: () => void;
@@ -57,6 +59,7 @@ const TopBar: React.FC<TopBarProps> = ({
   isFavorite,
   cursorState,
 }) => {
+  const { t } = useTranslation();
   return (
     <div className="h-16 bg-white border-b border-gray-200 px-4 flex items-center justify-between shadow-sm">
       <div className="flex space-x-2">
@@ -66,14 +69,14 @@ const TopBar: React.FC<TopBarProps> = ({
           onClick={onAddArrow}
         >
           <ArrowRight className="h-4 w-4 mr-2" />
-          Arrow
+          {t('common.arrow')}
         </button>
         <button
           className="inline-flex items-center px-3 py-2 border border-gray-200 rounded-md text-sm font-medium text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
           onClick={onAddText}
         >
           <Type className="h-4 w-4 mr-2" />
-          Text
+          {t('common.text')}
         </button>
 
         <div className="h-6 w-px bg-gray-200 mx-2" />
@@ -84,21 +87,21 @@ const TopBar: React.FC<TopBarProps> = ({
           onClick={onCut}
         >
           <Scissors className="h-4 w-4 mr-2" />
-          Cut
+          {t('common.cut')}
         </button>
         <button
           className="inline-flex items-center px-3 py-2 border border-gray-200 rounded-md text-sm font-medium text-gray-700 bg-white hover:bg-gray-50"
           onClick={onCopy}
         >
           <Copy className="h-4 w-4 mr-2" />
-          Copy
+          {t('common.copy')}
         </button>
         <button
           className="inline-flex items-center px-3 py-2 border border-gray-200 rounded-md text-sm font-medium text-gray-700 bg-white hover:bg-gray-50"
           onClick={onPaste}
         >
           <Clipboard className="h-4 w-4 mr-2" />
-          Paste
+          {t('common.paste')}
         </button>
 
         <div className="h-6 w-px bg-gray-200 mx-2" />
@@ -109,14 +112,14 @@ const TopBar: React.FC<TopBarProps> = ({
           onClick={onBringForward}
         >
           <ChevronUp className="h-4 w-4 mr-2" />
-          Bring Forward
+          {t('common.bringForward')}
         </button>
         <button
           className="inline-flex items-center px-3 py-2 border border-gray-200 rounded-md text-sm font-medium text-gray-700 bg-white hover:bg-gray-50"
           onClick={onSendBackward}
         >
           <ChevronDown className="h-4 w-4 mr-2" />
-          Send Backward
+          {t('common.sendBackward')}
         </button>
 
         <div className="h-6 w-px bg-gray-200 mx-2" />
@@ -127,14 +130,14 @@ const TopBar: React.FC<TopBarProps> = ({
           onClick={onFlipHorizontal}
         >
           <FlipHorizontal className="h-4 w-4 mr-2" />
-          Flip H
+          {t('common.flipHorizontal')}
         </button>
         <button
           className="inline-flex items-center px-3 py-2 border border-gray-200 rounded-md text-sm font-medium text-gray-700 bg-white hover:bg-gray-50"
           onClick={onFlipVertical}
         >
           <FlipVertical className="h-4 w-4 mr-2" />
-          Flip V
+          {t('common.flipVertical')}
         </button>
 
         <div className="h-6 w-px bg-gray-200 mx-2" />
@@ -147,7 +150,7 @@ const TopBar: React.FC<TopBarProps> = ({
           onClick={onLock}
         >
           <Lock className="h-4 w-4 mr-2" />
-          Lock
+          {isLocked ? t('common.unlock') : t('common.lock')}
         </button>
         <button
           className={`inline-flex items-center px-3 py-2 border border-gray-200 rounded-md text-sm font-medium ${
@@ -156,14 +159,14 @@ const TopBar: React.FC<TopBarProps> = ({
           onClick={onFavorite}
         >
           <Star className="h-4 w-4 mr-2" />
-          Favorite
+          {t('common.favorite')}
         </button>
         <button
           className="inline-flex items-center px-3 py-2 border border-gray-200 rounded-md text-sm font-medium text-gray-700 bg-white hover:bg-gray-50"
           onClick={onCrop}
         >
           <Crop className="h-4 w-4 mr-2" />
-          Crop
+          {t('common.crop')}
         </button>
 
         {/* Opacity Slider */}
@@ -189,7 +192,7 @@ const TopBar: React.FC<TopBarProps> = ({
                 : 'hover:bg-gray-100 text-gray-600'
             }`}
             onClick={onToggleBrushMode}
-            title="Pincel/Brush"
+            title={t('common.brush')}
           >
             <PenTool className="h-4 w-4" />
           </button>
@@ -211,16 +214,19 @@ const TopBar: React.FC<TopBarProps> = ({
       </div>
 
       <div className="flex items-center space-x-4">
+        <LanguageSwitcher />
         <div className="flex space-x-2">
           <button
             className="p-2 text-gray-500 hover:text-gray-700 focus:outline-none"
             onClick={onUndo}
+            title={t('common.undo')}
           >
             <Undo2 className="h-5 w-5" />
           </button>
           <button
             className="p-2 text-gray-500 hover:text-gray-700 focus:outline-none"
             onClick={onRedo}
+            title={t('common.redo')}
           >
             <Redo2 className="h-5 w-5" />
           </button>
@@ -230,7 +236,7 @@ const TopBar: React.FC<TopBarProps> = ({
           onClick={onSaveClick}
         >
           <Save className="h-4 w-4 mr-2" />
-          Export
+          {t('common.export')}
         </button>
       </div>
     </div>

--- a/imuno/src/hooks/useTranslation.ts
+++ b/imuno/src/hooks/useTranslation.ts
@@ -1,0 +1,28 @@
+import { useTranslation as useI18nTranslation } from 'react-i18next';
+
+export const useTranslation = () => {
+  const { t, i18n } = useI18nTranslation();
+
+  const changeLanguage = (language: string) => {
+    i18n.changeLanguage(language);
+  };
+
+  const getCurrentLanguage = () => {
+    return i18n.language;
+  };
+
+  const getAvailableLanguages = () => {
+    return [
+      { code: 'pt-BR', name: t('languages.pt-BR') },
+      { code: 'en-US', name: t('languages.en-US') },
+      { code: 'es-ES', name: t('languages.es-ES') }
+    ];
+  };
+
+  return {
+    t,
+    changeLanguage,
+    getCurrentLanguage,
+    getAvailableLanguages
+  };
+};

--- a/imuno/src/i18n/index.ts
+++ b/imuno/src/i18n/index.ts
@@ -1,0 +1,40 @@
+import i18n from 'i18next';
+import { initReactI18next } from 'react-i18next';
+import LanguageDetector from 'i18next-browser-languagedetector';
+
+// Importar as traduções
+import ptBR from './locales/pt-BR.json';
+import enUS from './locales/en-US.json';
+import esES from './locales/es-ES.json';
+
+const resources = {
+  'pt-BR': {
+    translation: ptBR
+  },
+  'en-US': {
+    translation: enUS
+  },
+  'es-ES': {
+    translation: esES
+  }
+};
+
+i18n
+  .use(LanguageDetector)
+  .use(initReactI18next)
+  .init({
+    resources,
+    fallbackLng: 'pt-BR', // Idioma padrão
+    debug: false,
+    
+    detection: {
+      order: ['localStorage', 'navigator', 'htmlTag'],
+      caches: ['localStorage'],
+    },
+
+    interpolation: {
+      escapeValue: false, // React já faz escape por padrão
+    },
+  });
+
+export default i18n;

--- a/imuno/src/i18n/locales/en-US.json
+++ b/imuno/src/i18n/locales/en-US.json
@@ -1,0 +1,73 @@
+{
+  "common": {
+    "search": "Search",
+    "export": "Export",
+    "save": "Save",
+    "undo": "Undo",
+    "redo": "Redo",
+    "cut": "Cut",
+    "copy": "Copy",
+    "paste": "Paste",
+    "lock": "Lock",
+    "unlock": "Unlock",
+    "favorite": "Favorite",
+    "crop": "Crop",
+    "arrow": "Arrow",
+    "text": "Text",
+    "brush": "Brush",
+    "opacity": "Opacity",
+    "bringForward": "Bring Forward",
+    "sendBackward": "Send Backward",
+    "flipHorizontal": "Flip Horizontal",
+    "flipVertical": "Flip Vertical",
+    "ruler": "Ruler",
+    "grid": "Grid",
+    "preview": "Preview",
+    "zoom": "Zoom",
+    "canvasColor": "Canvas Color",
+    "language": "Language"
+  },
+  "categories": {
+    "immunology": "Immunology",
+    "anatomy": "Anatomy",
+    "virus": "Virus",
+    "cellsAndOrganelles": "Cells and Organelles",
+    "proteins": "Proteins",
+    "equipment": "Equipment"
+  },
+  "subcategories": {
+    "organSystem": "Organ System",
+    "skeletalSystem": "Skeletal System",
+    "reproductiveSystem": "Reproductive System",
+    "circulatorySystem": "Circulatory System",
+    "lymphaticSystem": "Lymphatic System",
+    "cellularStructures": "Cellular Structures",
+    "immuneCells": "Immune Cells",
+    "stemCells": "Stem Cells",
+    "otherCells": "Other Cells"
+  },
+  "notifications": {
+    "itemCopied": "Item copied to clipboard",
+    "itemsCopied": "{{count}} items copied to clipboard",
+    "itemCut": "Item cut to clipboard",
+    "itemsCut": "{{count}} items cut to clipboard",
+    "itemPasted": "Item pasted successfully",
+    "itemsPasted": "{{count}} items pasted successfully",
+    "noItemSelected": "No item selected to copy",
+    "noItemToCut": "No item selected to cut",
+    "nothingToPaste": "Nothing to paste. Copy an item first.",
+    "cannotCutLocked": "Cannot cut locked items",
+    "loadingSvg": "Loading SVG...",
+    "errorLoadingSvg": "Error loading SVG",
+    "doubleClickToEdit": "Double click to edit"
+  },
+  "languages": {
+    "pt-BR": "Português (Brasil)",
+    "en-US": "English (US)",
+    "es-ES": "Español (España)"
+  },
+  "search": {
+    "placeholder": "Search icons...",
+    "noResults": "No items found."
+  }
+}

--- a/imuno/src/i18n/locales/es-ES.json
+++ b/imuno/src/i18n/locales/es-ES.json
@@ -1,0 +1,73 @@
+{
+  "common": {
+    "search": "Buscar",
+    "export": "Exportar",
+    "save": "Guardar",
+    "undo": "Deshacer",
+    "redo": "Rehacer",
+    "cut": "Cortar",
+    "copy": "Copiar",
+    "paste": "Pegar",
+    "lock": "Bloquear",
+    "unlock": "Desbloquear",
+    "favorite": "Favorito",
+    "crop": "Recortar",
+    "arrow": "Flecha",
+    "text": "Texto",
+    "brush": "Pincel",
+    "opacity": "Opacidad",
+    "bringForward": "Traer al frente",
+    "sendBackward": "Enviar atrás",
+    "flipHorizontal": "Voltear horizontalmente",
+    "flipVertical": "Voltear verticalmente",
+    "ruler": "Regla",
+    "grid": "Cuadrícula",
+    "preview": "Vista previa",
+    "zoom": "Zoom",
+    "canvasColor": "Color del lienzo",
+    "language": "Idioma"
+  },
+  "categories": {
+    "immunology": "Inmunología",
+    "anatomy": "Anatomía",
+    "virus": "Virus",
+    "cellsAndOrganelles": "Células y Orgánulos",
+    "proteins": "Proteínas",
+    "equipment": "Equipos"
+  },
+  "subcategories": {
+    "organSystem": "Sistema de Órganos",
+    "skeletalSystem": "Sistema Esquelético",
+    "reproductiveSystem": "Sistema Reproductivo",
+    "circulatorySystem": "Sistema Circulatorio",
+    "lymphaticSystem": "Sistema Linfático",
+    "cellularStructures": "Estructuras Celulares",
+    "immuneCells": "Células Inmunes",
+    "stemCells": "Células Madre",
+    "otherCells": "Otras Células"
+  },
+  "notifications": {
+    "itemCopied": "Elemento copiado al portapapeles",
+    "itemsCopied": "{{count}} elementos copiados al portapapeles",
+    "itemCut": "Elemento cortado al portapapeles",
+    "itemsCut": "{{count}} elementos cortados al portapapeles",
+    "itemPasted": "Elemento pegado exitosamente",
+    "itemsPasted": "{{count}} elementos pegados exitosamente",
+    "noItemSelected": "Ningún elemento seleccionado para copiar",
+    "noItemToCut": "Ningún elemento seleccionado para cortar",
+    "nothingToPaste": "Nada que pegar. Copia un elemento primero.",
+    "cannotCutLocked": "No se pueden cortar elementos bloqueados",
+    "loadingSvg": "Cargando SVG...",
+    "errorLoadingSvg": "Error al cargar SVG",
+    "doubleClickToEdit": "Doble clic para editar"
+  },
+  "languages": {
+    "pt-BR": "Português (Brasil)",
+    "en-US": "English (US)",
+    "es-ES": "Español (España)"
+  },
+  "search": {
+    "placeholder": "Buscar iconos...",
+    "noResults": "No se encontraron elementos."
+  }
+}

--- a/imuno/src/i18n/locales/pt-BR.json
+++ b/imuno/src/i18n/locales/pt-BR.json
@@ -1,0 +1,73 @@
+{
+  "common": {
+    "search": "Pesquisar",
+    "export": "Exportar",
+    "save": "Salvar",
+    "undo": "Desfazer",
+    "redo": "Refazer",
+    "cut": "Recortar",
+    "copy": "Copiar",
+    "paste": "Colar",
+    "lock": "Bloquear",
+    "unlock": "Desbloquear",
+    "favorite": "Favorito",
+    "crop": "Recortar",
+    "arrow": "Seta",
+    "text": "Texto",
+    "brush": "Pincel",
+    "opacity": "Opacidade",
+    "bringForward": "Trazer para frente",
+    "sendBackward": "Enviar para trás",
+    "flipHorizontal": "Inverter horizontalmente",
+    "flipVertical": "Inverter verticalmente",
+    "ruler": "Régua",
+    "grid": "Grade",
+    "preview": "Visualizar",
+    "zoom": "Zoom",
+    "canvasColor": "Cor do canvas",
+    "language": "Idioma"
+  },
+  "categories": {
+    "immunology": "Imunologia",
+    "anatomy": "Anatomia",
+    "virus": "Vírus",
+    "cellsAndOrganelles": "Células e Organelas",
+    "proteins": "Proteínas",
+    "equipment": "Equipamentos"
+  },
+  "subcategories": {
+    "organSystem": "Sistema de Órgãos",
+    "skeletalSystem": "Sistema Esquelético",
+    "reproductiveSystem": "Sistema Reprodutivo",
+    "circulatorySystem": "Sistema Circulatório",
+    "lymphaticSystem": "Sistema Linfático",
+    "cellularStructures": "Estruturas Celulares",
+    "immuneCells": "Células Imunes",
+    "stemCells": "Células-Tronco",
+    "otherCells": "Outras Células"
+  },
+  "notifications": {
+    "itemCopied": "Item copiado para a área de transferência",
+    "itemsCopied": "{{count}} itens copiados para a área de transferência",
+    "itemCut": "Item recortado para a área de transferência",
+    "itemsCut": "{{count}} itens recortados para a área de transferência",
+    "itemPasted": "Item colado com sucesso",
+    "itemsPasted": "{{count}} itens colados com sucesso",
+    "noItemSelected": "Nenhum item selecionado para copiar",
+    "noItemToCut": "Nenhum item selecionado para recortar",
+    "nothingToPaste": "Nada para colar. Copie um item primeiro.",
+    "cannotCutLocked": "Não é possível recortar itens bloqueados",
+    "loadingSvg": "Carregando SVG...",
+    "errorLoadingSvg": "Erro ao carregar SVG",
+    "doubleClickToEdit": "Clique duplo para editar"
+  },
+  "languages": {
+    "pt-BR": "Português (Brasil)",
+    "en-US": "English (US)",
+    "es-ES": "Español (España)"
+  },
+  "search": {
+    "placeholder": "Pesquisar ícones...",
+    "noResults": "Nenhum item encontrado."
+  }
+}

--- a/imuno/src/main.tsx
+++ b/imuno/src/main.tsx
@@ -2,6 +2,7 @@ import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import App from './App.tsx';
 import './index.css';
+import './i18n';
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>


### PR DESCRIPTION
**Resumo:**
Implementa i18n com i18next + react-i18next e detecção automática (fallback pt-BR).
Adiciona LanguageSwitcher na TopBar e hook useTranslation.
Traduz UI (botões, tooltips, placeholders, notificações).
Traduções de categorias e subcategorias (inclui “Cells and Organelles”: Immune/Stem/Other Cells).
Ajusta SideBar para mapear chaves dos dados para chaves de tradução.
Atualiza componentes: TopBar, SideBar, SearchBar, RightControls, App.
Adiciona documentação de i18n.

**Detalhes técnicos:**
Pacotes: react-i18next, i18next, i18next-browser-languagedetector.
Configuração em src/i18n/index.ts; locales pt-BR/en-US/es-ES.
Import do i18n em src/main.tsx.
Mapeamentos em SideBar para categorias/subcategorias.
Build e lint OK.

**Testes manuais:**
Trocar idioma via seletor na TopBar.
Verificar traduções de categorias/subcategorias no SideBar.
Conferir botões/tooltip/placeholder/notificações nos três idiomas.
Reload: preferência mantida via localStorage.